### PR TITLE
create unique prefix per hub

### DIFF
--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -14,6 +14,7 @@ from .froniusmodbusclient import FroniusModbusClient
 
 from .const import (
     DOMAIN,
+    ENTITY_PREFIX,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ class Hub:
         """Init hub."""
         self._hass = hass
         self._name = name
+        self._entity_prefix = f'{ENTITY_PREFIX}_{name.lower()}_'
 
         self._id = f'{name.lower()}_{host.lower().replace('.','')}'
         self.online = True        
@@ -112,6 +114,11 @@ class Hub:
     def hub_id(self) -> str:
         """ID for hub."""
         return self._id
+
+    @property
+    def entity_prefix(self) -> str:
+        """Entity prefix for hub."""
+        return self._entity_prefix
 
     @callback
     def async_add_hub_entity(self, update_callback):

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -3,7 +3,6 @@ from typing import Optional, Dict, Any
 
 from .const import (
     STORAGE_NUMBER_TYPES,
-    ENTITY_PREFIX,
 )
 
 from homeassistant.core import callback
@@ -34,7 +33,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
                 max = number_info[2]['max']
 
             number = FroniusModbusNumber(
-                ENTITY_PREFIX,
+                hub.entity_prefix,
                 hub,
                 hub.device_info_storage,
                 number_info[0],

--- a/custom_components/fronius_modbus/sensor.py
+++ b/custom_components/fronius_modbus/sensor.py
@@ -22,7 +22,6 @@ from .const import (
     INVERTER_STORAGE_SENSOR_TYPES,
     METER_SENSOR_TYPES,
     STORAGE_SENSOR_TYPES,
-    ENTITY_PREFIX,
 )
 from .hub import Hub
 from .base import FroniusModbusBaseEntity
@@ -41,7 +40,7 @@ async def async_setup_entry(
 
     for sensor_info in INVERTER_SENSOR_TYPES.values():
         sensor = FroniusModbusSensor(
-            platform_name = ENTITY_PREFIX,
+            platform_name = hub.entity_prefix,
             hub = hub,
             device_info = hub.device_info_inverter,
             name = sensor_info[0],
@@ -56,7 +55,7 @@ async def async_setup_entry(
 
     for sensor_info in INVERTER_SYMO_SENSOR_TYPES.values():
         sensor = FroniusModbusSensor(
-            platform_name = ENTITY_PREFIX,
+            platform_name = hub.entity_prefix,
             hub = hub,
             device_info = hub.device_info_inverter,
             name = sensor_info[0],
@@ -73,7 +72,7 @@ async def async_setup_entry(
         meter_id = '1'
         for sensor_info in METER_SENSOR_TYPES.values():
             sensor = FroniusModbusSensor(
-                platform_name = ENTITY_PREFIX,
+                platform_name = hub.entity_prefix,
                 hub = hub,
                 device_info = hub.get_device_info_meter(meter_id),
                 name = f'Meter {meter_id} ' + sensor_info[0],
@@ -89,7 +88,7 @@ async def async_setup_entry(
     if hub.storage_configured:
         for sensor_info in INVERTER_STORAGE_SENSOR_TYPES.values():
             sensor = FroniusModbusSensor(
-                platform_name = ENTITY_PREFIX,
+                platform_name = hub.entity_prefix,
                 hub = hub,
                 device_info = hub.device_info_inverter,
                 name = sensor_info[0],
@@ -104,7 +103,7 @@ async def async_setup_entry(
 
         for sensor_info in STORAGE_SENSOR_TYPES.values():
             sensor = FroniusModbusSensor(
-                platform_name = ENTITY_PREFIX,
+                platform_name = hub.entity_prefix,
                 hub = hub,
                 device_info = hub.device_info_storage,
                 name = sensor_info[0],


### PR DESCRIPTION
If you add multiple inverter then HA complains about already used entity keys.

Let's fix this by making the entity keys unique per hub.

Should fix https://github.com/redpomodoro/fronius_modbus/issues/35

---

Note: I do not have experience with HA integrations. I just changed it on my system to make it work. Please let me know if you are aware of a better/more "standard" way to do this.