### PR TITLE
Fix pymodbus

### DIFF
--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -5,12 +5,17 @@
 import logging
 import operator
 #from datetime import timedelta, datetime
-from typing import Optional, Literal
+from typing import Literal
 import struct
 import asyncio
 
 from pymodbus.client import AsyncModbusTcpClient
-from pymodbus.utilities import unpack_bitstring
+try:
+    # For newer pymodbus versions (3.9.x+)
+    from pymodbus.pdu.pdu import unpack_bitstring
+except ImportError:
+    # For older pymodbus versions (3.8.x and below)
+    from pymodbus.utilities import unpack_bitstring
 from pymodbus.exceptions import ModbusIOException, ConnectionException
 from pymodbus import ExceptionResponse
 

--- a/custom_components/fronius_modbus/manifest.json
+++ b/custom_components/fronius_modbus/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/redpomodoro/fronius_modbus/",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/redpomodoro/fronius_modbus/issues",
-    "requirements": ["pymodbus==3.8.3"],
-    "version": "0.1.7"
+    "requirements": ["pymodbus>=3.8.3"],
+    "version": "0.1.8"
   }


### PR DESCRIPTION
Summary
==

This fixes issue #44 when a new version of pymodbus was used by HA.

Before: 
<img width="320" height="111" alt="Screenshot 2025-07-11 at 1 37 15 pm" src="https://github.com/user-attachments/assets/0d6dd0bd-6b77-406b-b43e-d18e64e7b92e" />


After this fix the integration loaded:
<img width="325" height="110" alt="Screenshot 2025-07-11 at 1 34 18 pm" src="https://github.com/user-attachments/assets/3f48bdee-1ab7-4e27-9fe8-1617a05cc428" />

(This fix has been created by using Claude Code)
