### PR TITLE
fix: set discharge limit value

### DIFF
--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -261,7 +261,7 @@ class Hub:
 
     @toggle_busy
     async def set_discharge_limit(self, value):
-        await self._client.set_charge_limit(value)
+        await self._client.set_discharge_limit(value)
 
     @toggle_busy
     async def set_grid_charge_power(self, value):


### PR DESCRIPTION
I was not able to set the discharge limit value.
The `set_discharge_limit` method was calling `set_charge_limit` instead of `set_discharge_limit`.

I think this should fix https://github.com/redpomodoro/fronius_modbus/issues/48 & https://github.com/redpomodoro/fronius_modbus/issues/67