### PR TITLE
handle `None` return for `read_holding_registers()` in `get_registers()`

### DIFF
--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -112,15 +112,12 @@ class ExtModbusClient:
 
     async def get_registers(self, unit_id, address, count, retries = 0):
         data = await self.read_holding_registers(unit_id=unit_id, address=address, count=count)
-        if data.isError():
+        if data is None or data.isError():
             if isinstance(data,ModbusIOException):
                 if retries < 1:
                     _LOGGER.debug(f"IO Error: {data}. Retrying...")
                     return await self.get_registers(address=address, count=count, retries = retries + 1)
-                else:
-                    _LOGGER.error(f"error reading register: {address} count: {count} unit id: {unit_id} error: {data} ")
-            else:
-                _LOGGER.error(f"error reading register: {address} count: {count} unit id: {unit_id} error: {data} ")
+            _LOGGER.error(f"error reading register: {address} count: {count} unit id: {unit_id} error: {data} ")
             return None
         return data.registers
 


### PR DESCRIPTION
`read_holding_registers()` returns `None` for various errors. Make `get_registers()` handle this error case gracefully.

In addition I simplified an unnecessary duplication in the logging code.

This should avoid the following errors:

```
Error reading meter info unit id: 200
Traceback (most recent call last):
  File "/config/custom_components/fronius_modbus/froniusmodbusclient.py", line 92, in init_data
    result = await self.read_device_info_data(prefix=f'm{i+1}_', unit_id=unit_id)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/fronius_modbus/froniusmodbusclient.py", line 146, in read_device_info_data
    regs = await self.get_registers(unit_id=unit_id, address=COMMON_ADDRESS, count=65)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/fronius_modbus/extmodbusclient.py", line 115, in get_registers
    if data.isError():
       ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isError'
```