### PR TITLE
Fix manual storage limit watt conversion

### DIFF
--- a/custom_components/fronius_modbus/froniusmodbusclient.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient.py
@@ -538,14 +538,20 @@ class FroniusModbusClient(ExtModbusClient):
         minimum_reserve = round(minimum_reserve * 100)
         await self.write_registers(unit_id=self._inverter_unit_id, address=MINIMUM_RESERVE_ADDRESS, payload=[minimum_reserve])
 
+    def power_w_to_rate_percent(self, power_w, max_rate_w):
+        if max_rate_w <= 0:
+            _LOGGER.error(f'Attempted to convert power with invalid maximum rate. Value: {max_rate_w}')
+            return 0
+        if power_w > max_rate_w:
+            return 100
+        if power_w < max_rate_w * -1:
+            return -100
+        return power_w / max_rate_w * 100
+
     async def set_discharge_rate_w(self, discharge_rate_w):
-        if discharge_rate_w > self.max_discharge_rate_w:
-            discharge_rate = 100
-        elif discharge_rate_w < self.max_discharge_rate_w * -1:
-            discharge_rate = -100
-        else:
-            discharge_rate = discharge_rate_w / self.max_discharge_rate_w * 100
+        discharge_rate = self.power_w_to_rate_percent(discharge_rate_w, self.max_discharge_rate_w)
         await self.set_discharge_rate(discharge_rate)
+        return discharge_rate
 
     async def set_discharge_rate(self, discharge_rate):
         if discharge_rate < 0:
@@ -555,33 +561,29 @@ class FroniusModbusClient(ExtModbusClient):
         await self.write_registers(unit_id=self._inverter_unit_id, address=DISCHARGE_RATE_ADDRESS, payload=[discharge_rate])
 
     async def set_charge_rate_w(self, charge_rate_w):
-        if charge_rate_w > self.max_charge_rate_w:
-            charge_rate = 100
-        elif charge_rate_w < self.max_charge_rate_w * -1:
-            charge_rate = -100
-        else:
-            charge_rate = charge_rate_w / self.max_charge_rate_w * 100
+        charge_rate = self.power_w_to_rate_percent(charge_rate_w, self.max_charge_rate_w)
         await self.set_charge_rate(charge_rate)
+        return charge_rate
 
     async def set_grid_charge_power(self, value):
         if self.storage_extended_control_mode == 4:
-            await self.set_discharge_rate_w(value * -1)
-            self.data['grid_charge_power'] = value
+            discharge_rate = await self.set_discharge_rate_w(value * -1)
+            self.data['grid_charge_power'] = discharge_rate * -1
         else:
             return
 
     async def set_grid_discharge_power(self, value):
         if self.storage_extended_control_mode == 5:
-            await self.set_charge_rate_w(value * -1)
-            self.data['grid_discharge_power'] = value
+            charge_rate = await self.set_charge_rate_w(value * -1)
+            self.data['grid_discharge_power'] = charge_rate * -1
         else:
             return
         
     async def set_charge_limit(self, value):
         if self.storage_extended_control_mode in [1,3,6]:
             # only change when charge limit is used
-            await self.set_charge_rate_w(value)
-            self.data['charge_limit'] = value
+            charge_rate = await self.set_charge_rate_w(value)
+            self.data['charge_limit'] = charge_rate
         elif self.storage_extended_control_mode in [4,5,7]:
             return
         elif self.storage_extended_control_mode in [0,2]:
@@ -590,8 +592,8 @@ class FroniusModbusClient(ExtModbusClient):
     async def set_discharge_limit(self, value):
         if self.storage_extended_control_mode in [2,3,7]:
             # only change when discharge limit is used
-            await self.set_discharge_rate_w(value)
-            self.data['discharge_limit'] = value
+            discharge_rate = await self.set_discharge_rate_w(value)
+            self.data['discharge_limit'] = discharge_rate
         elif self.storage_extended_control_mode in [4,5,6]:
             return
         elif self.storage_extended_control_mode in [0,1]:

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import asyncio
 from datetime import timedelta
 from typing import Optional
 from importlib.metadata import version
@@ -41,8 +42,11 @@ class Hub:
     def toggle_busy(func):
         async def wrapper(self, *args, **kwargs):
             if self._busy:
-                #_LOGGER.debug(f"skip {func.__name__} hub busy") 
-                return
+                if func.__name__ == "async_refresh_modbus_data":
+                    #_LOGGER.debug(f"skip {func.__name__} hub busy")
+                    return
+                while self._busy:
+                    await asyncio.sleep(0.1)
             self._busy = True
             error = None
             try:
@@ -261,7 +265,7 @@ class Hub:
 
     @toggle_busy
     async def set_discharge_limit(self, value):
-        await self._client.set_charge_limit(value)
+        await self._client.set_discharge_limit(value)
 
     @toggle_busy
     async def set_grid_charge_power(self, value):

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -15,6 +15,7 @@ from .froniusmodbusclient import FroniusModbusClient
 
 from .const import (
     DOMAIN,
+    STORAGE_EXT_CONTROL_MODE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,6 +139,12 @@ class Hub:
             self._unsub_interval_method = None
             self.close()
 
+    @callback
+    def async_update_entities(self):
+        """Push updated hub data to all registered entities."""
+        for update_callback in self._entities:
+            update_callback()
+
     @toggle_busy
     async def async_refresh_modbus_data(self, _now: Optional[int] = None) -> dict:
         """Time to update."""
@@ -193,8 +200,7 @@ class Hub:
 
 
         if update_result:
-            for update_callback in self._entities:
-                update_callback()
+            self.async_update_entities()
 
     @toggle_busy
     async def test_connection(self) -> bool:
@@ -254,25 +260,33 @@ class Hub:
             await self._client.set_block_charge_mode()
         elif mode == 8:
             await self._client.set_calibrate_mode()
+        if mode in STORAGE_EXT_CONTROL_MODE:
+            self._client.data['ext_control_mode'] = STORAGE_EXT_CONTROL_MODE[mode]
+        self.async_update_entities()
 
     @toggle_busy
     async def set_minimum_reserve(self, value):
         await self._client.set_minimum_reserve(value)
+        self.async_update_entities()
 
     @toggle_busy
     async def set_charge_limit(self, value):
         await self._client.set_charge_limit(value)
+        self.async_update_entities()
 
     @toggle_busy
     async def set_discharge_limit(self, value):
         await self._client.set_discharge_limit(value)
+        self.async_update_entities()
 
     @toggle_busy
     async def set_grid_charge_power(self, value):
         await self._client.set_grid_charge_power(value)
+        self.async_update_entities()
            
     @toggle_busy
     async def set_grid_discharge_power(self, value):
         await self._client.set_grid_discharge_power(value)
+        self.async_update_entities()
 
 

--- a/custom_components/fronius_modbus/manifest.json
+++ b/custom_components/fronius_modbus/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/redpomodoro/fronius_modbus/issues",
     "requirements": ["pymodbus>=3.11.1"],
-    "version": "0.1.9"
+    "version": "0.1.9-bgewehr1"
   }

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -53,18 +53,25 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
     """Representation of an Battery Storage Modbus number."""
 
+    def _rate_to_power_w(self, value):
+        if self._key in ['grid_discharge_power','discharge_limit']:
+            return round(value / 100.0 * self._hub.max_discharge_rate_w,0)
+        if self._key in ['grid_charge_power','charge_limit']:
+            return round(value / 100.0 * self._hub.max_charge_rate_w,0)
+        return value
+
     @property
-    def state(self):
-        """Return the state of the sensor."""
+    def native_value(self) -> float:
+        """Return the number value in its native unit."""
 
         if self._key in self._hub.data:
-            if self._key in ['grid_discharge_power','discharge_limit']:
-                value = round(self._hub.data[self._key] / 100.0 * self._hub.max_discharge_rate_w,0)
-            elif self._key in ['grid_charge_power','charge_limit']:
-                value = round(self._hub.data[self._key] / 100.0 * self._hub.max_charge_rate_w,0)
-            else:
-                value = self._hub.data[self._key]    
-            return value
+            return self._rate_to_power_w(self._hub.data[self._key])
+
+    @property
+    def state(self):
+        """Return the state of the number."""
+
+        return self.native_value
 
     # @property
     # def native_value(self) -> float:

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -98,7 +98,6 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
             await self._hub.set_grid_discharge_power(value)
 
         #_LOGGER.debug(f"Number {self._key} set to {value}")
-        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/fronius_modbus/select.py
+++ b/custom_components/fronius_modbus/select.py
@@ -57,7 +57,3 @@ class FroniusModbusSelect(FroniusModbusBaseEntity, SelectEntity):
         new_mode = get_key(self._options_dict, option)
 
         await self._hub.set_mode(new_mode)
-
-        self._hub.data[self._key] = option
-        #self._hub.storage_extended_control_mode = new_mode
-        self.async_write_ha_state()


### PR DESCRIPTION
Fixes manual storage limit inputs when values are entered in watts.

Changes:
- Route `set_discharge_limit()` through the discharge setter instead of the charge setter.
- Keep cached storage limit values in percent after writing watt-based number inputs.
- Reuse one conversion helper for watt-to-percent rate conversion.

Validated with `python -m compileall custom_components/fronius_modbus`.