### PR TITLE
fix: import unpack_bitstring from pymodbus.pdu.utils (pymodbus 3.11+ / HA 2026.x)

### DIFF
--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -11,11 +11,15 @@ import asyncio
 
 from pymodbus.client import AsyncModbusTcpClient
 try:
-    # For newer pymodbus versions (3.9.x+)
-    from pymodbus.pdu.pdu import unpack_bitstring
+    # pymodbus 3.11+ (HA 2026.x): unpack_bitstring moved to pdu.utils
+    from pymodbus.pdu.utils import unpack_bitstring
 except ImportError:
-    # For older pymodbus versions (3.8.x and below)
-    from pymodbus.utilities import unpack_bitstring
+    try:
+        # pymodbus 3.9.x
+        from pymodbus.pdu.pdu import unpack_bitstring
+    except ImportError:
+        # pymodbus <=3.8
+        from pymodbus.utilities import unpack_bitstring
 from pymodbus.exceptions import ModbusIOException, ConnectionException
 from pymodbus import ExceptionResponse
 


### PR DESCRIPTION
## Problem
On HA 2026.x (pymodbus **3.13.1**, Python 3.14) the integration crashes at import:
```
ImportError: cannot import name 'unpack_bitstring' from 'pymodbus.utilities'
```
In pymodbus **3.11+**, `unpack_bitstring` was moved to **`pymodbus.pdu.utils`**. The current try/except in `extmodbusclient.py` only tries `pymodbus.pdu.pdu` and `pymodbus.utilities` — both fail on 3.11+, so setup fails.

## Fix
Add `pymodbus.pdu.utils` as the first import path, keeping the older locations as fallbacks (fully backwards compatible).

## Tested
HA 2026.7 / pymodbus 3.13.1 / Python 3.14: integration now loads without ImportError, entities restored.

Fixes #96 (relates #77).